### PR TITLE
fixed .buildpacks heroku-buildpack-casperjs url(commit id)

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
-https://github.com/seabre/heroku-buildpack-casperjs.git#9cb1675afb6de613d0b9d94d00f79f5599b1fa85
+https://github.com/seabre/heroku-buildpack-casperjs.git#d803ffb58d8caccaefdc94d9d4ddefbed7e86251
 https://github.com/seabre/heroku-buildpack-clojure.git#dc7edf8f876654d41025565394caf2b51e8e596f


### PR DESCRIPTION
phantomjs 1.9.2 -> 1.9.8
